### PR TITLE
Fix typo in bounds

### DIFF
--- a/include/benchmarks/DataTypes.h
+++ b/include/benchmarks/DataTypes.h
@@ -47,7 +47,7 @@ namespace benchmarks {
 				 const double &z_min, 
 				 const double &z_max) {
 			xmin = x_min;
-			ymax = x_max;
+			xmax = x_max;
 			ymin = y_min;
 			ymax = y_max;
 			zmin = z_min;


### PR DESCRIPTION
Without this fix, `run_collision_benchmark.py` never terminates for me because it can never sample an x coordinate.  How did this ever work? d-: